### PR TITLE
Feature/login

### DIFF
--- a/TradingSystem/stockbroker.cpp
+++ b/TradingSystem/stockbroker.cpp
@@ -1,19 +1,33 @@
 #include "kiwer_api.cpp"
 #include "nemo_api.cpp"
 #include <exception>
+#include <sstream>
 
 interface StockBroker {
-	virtual void login(std::string ID, std::string password) = 0;
+	virtual bool login(std::string ID, std::string password) = 0;
 	virtual void buy(std::string stockCode, int count, int price) = 0;
 	virtual void sell(std::string stockCode, int count, int price) = 0;
 	virtual int currentPrice(std::string stockCode) = 0;
 };
 
-class KiwerStockBroker : public StockBroker, public KiwerAPI {
+class KiwerStockBroker : public StockBroker {
 public:
-	void login(std::string ID, std::string password) override {
-		login(ID, password);
-	}	
+	bool login(std::string ID, std::string password) override {
+		std::ostringstream oss = {};
+		auto oldCoutStreamBuf = std::cout.rdbuf();
+		std::cout.rdbuf(oss.rdbuf());
+
+		kiwerAPI.login(ID, password);
+		if (oss.str().find("login success") != std::string::npos) {
+			std::cout.rdbuf(oldCoutStreamBuf);
+			std::cout << "Kiwer login success\n";
+			return true;
+		} else {
+			std::cout.rdbuf(oldCoutStreamBuf);
+			std::cout << "Kiwer login failed\n";
+			return false;
+		}
+	}
 
 	void buy(std::string stockCode, int count, int price) override {
 
@@ -26,12 +40,27 @@ public:
 	int currentPrice(std::string stockCode) override {
 		return 0;
 	}
+private:
+	KiwerAPI kiwerAPI;
 };
 
-class NemoStockBroker : public StockBroker, public NemoAPI {
+class NemoStockBroker : public StockBroker {
 public:
-	void login(std::string ID, std::string password) override {
-		certification(ID, password);
+	bool login(std::string ID, std::string password) override {
+		std::ostringstream oss = {};
+		auto oldCoutStreamBuf = std::cout.rdbuf();
+		std::cout.rdbuf(oss.rdbuf());
+
+		nemoAPI.certification(ID, password);
+		if (oss.str().find("login GOOD") != std::string::npos) {
+			std::cout.rdbuf(oldCoutStreamBuf);
+			std::cout << "Nemo login success\n";
+			return true;
+		} else {
+			std::cout.rdbuf(oldCoutStreamBuf);
+			std::cout << "Nemo login failed\n";
+			return false;
+		}
 	}
 
 	void buy(std::string stockCode, int count, int price) override {
@@ -45,6 +74,8 @@ public:
 	int currentPrice(std::string stockCode) override {
 		return 0;
 	}
+private:
+	NemoAPI nemoAPI;
 };
 
 class AutoTradingSystem {
@@ -79,8 +110,8 @@ public:
 		if (password.empty()) {
 			return false;
 		}
-		stockBroker->login(ID, password);
-		return true;
+
+		return stockBroker->login(ID, password);
 	}
 	void buy(std::string stockCode, int count, int price);
 	int currentPrice(std::string stockCode)

--- a/TradingSystem/test.cpp
+++ b/TradingSystem/test.cpp
@@ -83,7 +83,7 @@ TEST_F(AutoTradingFixture, ThrowNemoBlankID) {
 TEST_F(AutoTradingFixture, KiwerLogin) {
 	app.selectStockBrocker(KIWER_STOCK_BROCKER);
 
-	bool result = mockApp.login(NOT_IMPORTANT_ID, VALID_PASSWORD);
+	bool result = app.login(NOT_IMPORTANT_ID, VALID_PASSWORD);
 
 	EXPECT_EQ(true, result);
 }
@@ -91,16 +91,22 @@ TEST_F(AutoTradingFixture, KiwerLogin) {
 TEST_F(AutoTradingFixture, NemoLoginSuccess) {
 	app.selectStockBrocker(NEMO_STOCK_BROCKER);
 
-	bool result = mockApp.login(NOT_IMPORTANT_ID, VALID_PASSWORD);
+	bool result = app.login(NOT_IMPORTANT_ID, VALID_PASSWORD);
 
 	EXPECT_EQ(true, result);
 }
 
 TEST_F(AutoTradingFixture, MockLoginFail) {
 	EXPECT_CALL(mockStockBroker, login)
-		.WillRepeatedly(Return(false))
-		.Times(1);
+		.Times(1)
+		.WillOnce(Return(false));
 
+	bool result = mockApp.login(NOT_IMPORTANT_ID, VALID_PASSWORD);
+
+	EXPECT_EQ(false, result);
+}
+
+TEST_F(AutoTradingFixture, MockLoginFailWithInvalidPassward) {
 	bool result = mockApp.login(NOT_IMPORTANT_ID, INVALID_PASSWORD);
 
 	EXPECT_EQ(false, result);
@@ -108,8 +114,8 @@ TEST_F(AutoTradingFixture, MockLoginFail) {
 
 TEST_F(AutoTradingFixture, MockLoginSuccess) {
 	EXPECT_CALL(mockStockBroker, login)
-		.WillRepeatedly(Return(true))
-		.Times(1);
+		.Times(1)
+		.WillOnce(Return(true));
 
 	bool result = mockApp.login(NOT_IMPORTANT_ID, VALID_PASSWORD);
 


### PR DESCRIPTION
login 이 bool을 리턴하도록 변경됨에 따라
1. 각각의 Broker class에서의 login 함수 동작을 수정했습니다.
2. 이와 더불어 각각의 Broker class 는 더 이상 API class를 상속하지 않고, 멤버로 API class 변수를 갖게 변경하였는데, 이들 API는 데이터 멤버가 없으므로 포인터를 갖고있기보다 그냥 변수로 갖고 있게끔 변경했습니다.
3. test code를 변경된 내용에 맞게 변경했습니다.